### PR TITLE
Remove superfluous "os" import

### DIFF
--- a/du/diskusage.go
+++ b/du/diskusage.go
@@ -2,10 +2,7 @@
 
 package du
 
-import (
-	"os"
-	"syscall"
-)
+import "syscall"
 
 type DiskUsage struct {
 	stat *syscall.Statfs_t


### PR DESCRIPTION
Running `go get` complains about an extra unused import.

```
-> % go get github.com/ricochet2200/go-disk-usage/du
# github.com/ricochet2200/go-disk-usage/du
../../../ricochet2200/go-disk-usage/du/diskusage.go:6: imported and not used: "os"
```