### PR TITLE
fix: compatibility with FreeBSD

### DIFF
--- a/du/diskusage.go
+++ b/du/diskusage.go
@@ -25,7 +25,7 @@ func (du *DiskUsage) Free() uint64 {
 
 // Available return total available bytes on file system to an unprivileged user
 func (du *DiskUsage) Available() uint64 {
-	return du.stat.Bavail * uint64(du.stat.Bsize)
+	return uint64(du.stat.Bavail) * uint64(du.stat.Bsize)
 }
 
 // Size returns total size of the file system


### PR DESCRIPTION
Hi,

I try to build a project using `du` library on FreeBSD, but because of mess in `stat` structure across platforms, there is a problem with `int64` vs `uint64`. Thus I added a typecast into `Available` function, the same as already is in `Size`.

Regards