### PR TITLE
Use x/sys-package instead of syscall

### DIFF
--- a/du/diskusage.go
+++ b/du/diskusage.go
@@ -1,20 +1,25 @@
+//go:build !windows
 // +build !windows
 
 package du
 
-import "syscall"
+import (
+	"golang.org/x/sys/unix"
+)
 
 // DiskUsage contains usage data and provides user-friendly access methods
 type DiskUsage struct {
-	stat *syscall.Statfs_t
+	stat *unix.Statfs_t
 }
 
 // NewDiskUsages returns an object holding the disk usage of volumePath
 // or nil in case of error (invalid path, etc)
 func NewDiskUsage(volumePath string) *DiskUsage {
-
-	var stat syscall.Statfs_t
-	syscall.Statfs(volumePath, &stat)
+	stat := unix.Statfs_t{}
+	err := unix.Statfs(volumePath, &stat)
+	if err != nil {
+		return nil
+	}
 	return &DiskUsage{&stat}
 }
 

--- a/du/diskusage_windows.go
+++ b/du/diskusage_windows.go
@@ -1,8 +1,9 @@
 package du
 
 import (
-	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 type DiskUsage struct {
@@ -14,14 +15,13 @@ type DiskUsage struct {
 // NewDiskUsages returns an object holding the disk usage of volumePath
 // or nil in case of error (invalid path, etc)
 func NewDiskUsage(volumePath string) *DiskUsage {
-
-	h := syscall.MustLoadDLL("kernel32.dll")
+	h := windows.MustLoadDLL("kernel32.dll")
 	c := h.MustFindProc("GetDiskFreeSpaceExW")
 
 	du := &DiskUsage{}
 
 	c.Call(
-		uintptr(unsafe.Pointer(syscall.StringToUTF16Ptr(volumePath))),
+		uintptr(unsafe.Pointer(windows.StringToUTF16Ptr(volumePath))),
 		uintptr(unsafe.Pointer(&du.freeBytes)),
 		uintptr(unsafe.Pointer(&du.totalBytes)),
 		uintptr(unsafe.Pointer(&du.availBytes)))


### PR DESCRIPTION
According to syscalls readme, it has been deprecated in favor of the golang.org/x/sys repository. This PR replaces syscall usage with x/sys 