### PR TITLE
Fix wrong measures on linux arm64

### DIFF
--- a/du/blocksize.go
+++ b/du/blocksize.go
@@ -1,0 +1,7 @@
+//go:build !windows && !(arm64 && linux)
+
+package du
+
+func (du *DiskUsage) BlockSize() int {
+	return int(du.stat.Bsize)
+}

--- a/du/blocksize_arm64linux.go
+++ b/du/blocksize_arm64linux.go
@@ -1,0 +1,7 @@
+//go:build arm64 && linux
+
+package du
+
+func (du *DiskUsage) BlockSize() int {
+	return int(du.stat.Frsize)
+}

--- a/du/diskusage.go
+++ b/du/diskusage.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package du
@@ -20,17 +21,17 @@ func NewDiskUsage(volumePath string) *DiskUsage {
 
 // Free returns total free bytes on file system
 func (du *DiskUsage) Free() uint64 {
-	return du.stat.Bfree * uint64(du.stat.Bsize)
+	return du.stat.Bfree * uint64(du.BlockSize())
 }
 
 // Available return total available bytes on file system to an unprivileged user
 func (du *DiskUsage) Available() uint64 {
-	return du.stat.Bavail * uint64(du.stat.Bsize)
+	return du.stat.Bavail * uint64(du.BlockSize())
 }
 
 // Size returns total size of the file system
 func (du *DiskUsage) Size() uint64 {
-	return uint64(du.stat.Blocks) * uint64(du.stat.Bsize)
+	return uint64(du.stat.Blocks) * uint64(du.BlockSize())
 }
 
 // Used returns total bytes used in file system


### PR DESCRIPTION
Measures are wrong on linux ARM64 in a container with a macos arm64 (apple silicon) host, when measuring a filesystem that is a bind mount from the host to the container.

This is because the actual block size in Frsize and not Bsize in this case.